### PR TITLE
Fixes "linkifiedText" error when cancelling message

### DIFF
--- a/poe_api_wrapper/api.py
+++ b/poe_api_wrapper/api.py
@@ -897,7 +897,7 @@ class PoeApi:
         
     def cancel_message(self, chunk: dict):
         self.message_generating = False
-        variables = {"messageId": chunk["messageId"], "textLength": len(chunk["text"]), "linkifiedTextLength": len(chunk["linkifiedText"])}
+        variables = {"messageId": chunk["messageId"], "textLength": len(chunk["text"]))}
         self.send_request('gql_POST', 'ChatHelpers_messageCancel_Mutation', variables)
         
     def chat_break(self, bot: str, chatId: int=None, chatCode: str=None):


### PR DESCRIPTION
Removing `linkifiedText` fixes #81. I'm not sure what it does or if it's required at all, since it's not used in any other part of the code. Performing a network analysis on Poe gives the following request JSON, which has no mention of `linkifiedText`:
```
{"queryName":"stopMessage_messageCancel_Mutation","variables":{"messageId":xxx,"textLength":xxx},"extensions":{"hash":"xxx"}}
```
Removing `linkifiedTextLength` from line 900 in `api.py` fixes my problem
```
variables = {"messageId": chunk["messageId"], "textLength": len(chunk["text"]), "linkifiedTextLength": len(chunk["linkifiedText"])}
```

