### PR TITLE
Changing the query-hash key for `chat_break`

### DIFF
--- a/poe_api_wrapper/api.py
+++ b/poe_api_wrapper/api.py
@@ -913,7 +913,7 @@ class PoeApi:
         chatdata = self.get_threadData(bot, chatCode, chatId)
         chatId = chatdata['chatId']
         variables = {'chatId': chatId, 'clientNonce': generate_nonce()}
-        self.send_request('gql_POST', 'SendChatBreakMutation', variables)
+        self.send_request('gql_POST', 'ChatHelpers_addMessageBreakEdgeMutation_Mutation', variables)
             
     def delete_message(self, message_ids):
         variables = {'messageIds': message_ids}


### PR DESCRIPTION
## Problem
the `chat_break` is not working   ##effectively
See https://github.com/snowby666/poe-api-wrapper/issues/90

## Testing
When I run with the new changes, I can see the "Context cleared" message in the Poe UI, and
if I prompt the LLM with "what did we discuss so far?" I get "I'm afraid I don't have any record of a previous discussion we had"

Ran `tox`:
```
$ tox
py37: skipped because could not find python interpreter with spec(s): py37
py37: SKIP ⚠ in 0.47 seconds
.pkg: _optional_hooks> python /usr/local/python/3.10.13/lib/python3.10/site-packages/pyproject_api/_backend.py True setuptools.build_meta __legacy__
.pkg: get_requires_for_build_sdist> python /usr/local/python/3.10.13/lib/python3.10/site-packages/pyproject_api/_backend.py True setuptools.build_meta __legacy__
.pkg: get_requires_for_build_wheel> python /usr/local/python/3.10.13/lib/python3.10/site-packages/pyproject_api/_backend.py True setuptools.build_meta __legacy__
.pkg: prepare_metadata_for_build_wheel> python /usr/local/python/3.10.13/lib/python3.10/site-packages/pyproject_api/_backend.py True setuptools.build_meta __legacy__
.pkg: build_sdist> python /usr/local/python/3.10.13/lib/python3.10/site-packages/pyproject_api/_backend.py True setuptools.build_meta __legacy__
py38: install_package> python -I -m pip install --force-reinstall --no-deps /workspaces/poe-api-wrapper/.tox/.tmp/package/2/poe-api-wrapper-1.3.6.tar.gz
py38: commands[0]> python test.py
Enter your token: Q6v....
Initializing tests
test_** ...
[..]
Ran 21 tests in 79.804s

OK
```
![Screenshot 2023-12-27 at 1 17 33 PM](https://github.com/snowby666/poe-api-wrapper/assets/15260011/617fec09-d305-4187-8cc3-e9574e82a212)
