### PR TITLE
Fix: Replace sync queue with asyncio.Queue to prevent event loop blocking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 build/
 dist/
 .tox/
+.idea/
 playground/
 examples/
 langchain/


### PR DESCRIPTION

### Problem
When experiencing high QPS (Queries Per Second), the synchronous queue implementation can block the event loop, causing performance degradation and potential deadlocks.

### Solution
- Replace `queue.Queue()` with `asyncio.Queue()` for asynchronous queue operations
- Implement proper async/await patterns when interacting with the queue
- Add proper exception handling for queue operations

### Changes
- Changed `self.message_queues` initialization from `queue.Queue()` to `asyncio.Queue()`
- Updated queue operations to use async/await syntax
- Added exception handling for `QueueEmpty` cases
- Implemented `run_coroutine_threadsafe` for thread-safe queue operations (the ws client there is sync, we may need to change it into async, this is a trade-off)

### Related Issue
Today, my FastAPI backend experienced heavy user traffic that caused blocking issues. After debugging, I discovered the bottleneck was caused by the synchronous queue implementation. 😂

