### PR TITLE
fix: handle 'no_access' status for Claude-instant (a2) bot

### DIFF
--- a/poe_api_wrapper/api.py
+++ b/poe_api_wrapper/api.py
@@ -729,13 +729,19 @@ class PoeApi:
                         raise RuntimeError(f"Daily limit reached for {bot}.")
                     elif status == 'too_many_tokens':
                         raise RuntimeError(f"{message_data['data']['messageEdgeCreate']['statusMessage']}")
+                    elif status == 'no_access':
+                        raise RuntimeError(f"{message_data['data']['messageEdgeCreate']['statusMessage']}")
                     elif status in ('rate_limit_exceeded', 'concurrent_messages'):
                         self.delete_pending_messages(prompt_md5)
                         sleep(random.randint(4, 6))
                         for chunk in self.send_message(bot, message, chatId, chatCode, msgPrice, file_path, suggest_replies, timeout):
                             yield chunk
                         return
-                    
+
+                    chat_data = message_data['data']['messageEdgeCreate'].get('chat')
+                    if not chat_data:
+                        raise RuntimeError(f"Failed to create chat: {message_data['data']['messageEdgeCreate'].get('statusMessage', 'Unknown error')}")
+
                     logger.info(f"New Thread created | {message_data['data']['messageEdgeCreate']['chat']['chatCode']}")
                 
                 message_data = message_data['data']['messageEdgeCreate']['chat']
@@ -785,6 +791,8 @@ class PoeApi:
                     elif status == 'reached_limit':
                         raise RuntimeError(f"Daily limit reached for {bot}.")
                     elif status == 'too_many_tokens':
+                        raise RuntimeError(f"{message_data['data']['messageEdgeCreate']['statusMessage']}")
+                    elif status == 'no_access':
                         raise RuntimeError(f"{message_data['data']['messageEdgeCreate']['statusMessage']}")
                     elif status in ('rate_limit_exceeded', 'concurrent_messages'):
                         self.delete_pending_messages(prompt_md5)

--- a/poe_api_wrapper/async_api.py
+++ b/poe_api_wrapper/async_api.py
@@ -779,13 +779,19 @@ class AsyncPoeApi:
                         raise RuntimeError(f"Daily limit reached for {bot}.")
                     elif status == 'too_many_tokens':
                         raise RuntimeError(f"{message_data['data']['messageEdgeCreate']['statusMessage']}")
+                    elif status == 'no_access':
+                        raise RuntimeError(f"{message_data['data']['messageEdgeCreate']['statusMessage']}")
                     elif status in ('rate_limit_exceeded', 'concurrent_messages'):
                         await self.delete_pending_messages(prompt_md5)
                         await asyncio.sleep(random.randint(4, 6))
                         async for chunk in self.send_message(bot, message, chatId, chatCode, msgPrice, file_path, suggest_replies, timeout):
                             yield chunk
                         return
-                        
+
+                    chat_data = message_data['data']['messageEdgeCreate'].get('chat')
+                    if not chat_data:
+                        raise RuntimeError(f"Failed to create chat: {message_data['data']['messageEdgeCreate'].get('statusMessage', 'Unknown error')}")
+
                     logger.info(f"New Thread created | {message_data['data']['messageEdgeCreate']['chat']['chatCode']}")
                 
                 message_data = message_data['data']['messageEdgeCreate']['chat']
@@ -835,6 +841,8 @@ class AsyncPoeApi:
                     elif status == 'reached_limit':
                         raise RuntimeError(f"Daily limit reached for {bot}.")
                     elif status == 'too_many_tokens':
+                        raise RuntimeError(f"{message_data['data']['messageEdgeCreate']['statusMessage']}")
+                    elif status == 'no_access':
                         raise RuntimeError(f"{message_data['data']['messageEdgeCreate']['statusMessage']}")
                     elif status in ('rate_limit_exceeded', 'concurrent_messages'):
                         await self.delete_pending_messages(prompt_md5)

--- a/poe_api_wrapper/async_api.py
+++ b/poe_api_wrapper/async_api.py
@@ -381,7 +381,7 @@ class AsyncPoeApi:
         if chatId in self.message_queues:
             while not self.message_queues[chatId].empty():
                 try:
-                    await self.message_queues[chatId].get_nowait()
+                    self.message_queues[chatId].get_nowait()
                 except asyncio.QueueEmpty:
                     pass
             del self.message_queues[chatId]


### PR DESCRIPTION
## Description
This PR fixes a bug where the code crashes when attempting to access Claude-instant (a2) bot, which is now private and inaccessible. The current code doesn't handle the `no_access` status properly, resulting in a `TypeError` when trying to access attributes of `None`.

### Changes Made
1. Added handling for `no_access` status in message response
2. Added safety checks before accessing chat data
3. Improved error handling to provide clearer error messages

### Additional Notes
The README.md currently uses Claude-instant (a2) in its examples. Since this bot is no longer accessible, it would be helpful to update the examples to use a different bot that's currently available.

### Error Details
When trying to access Claude-instant (a2), the API returns:
```json
{
    "data": {
        "messageEdgeCreate": {
            "message": None,
            "status": "no_access",
            "statusMessage": "Claude-instant has been made private by its creator. Your chat history is saved but you won't be able to send new messages to this bot. Try @mentioning another bot."
        }
    }
}
```

Without proper handling, this leads to:
```python
TypeError: 'NoneType' object is not subscriptable
```