### PR TITLE
Fix: Resolve missing module import in FastAPI server

### DIFF
--- a/poe_api_wrapper/openai/api.py
+++ b/poe_api_wrapper/openai/api.py
@@ -4,8 +4,8 @@ from fastapi.middleware.cors import CORSMiddleware
 from daphne.cli import CommandLineInterface
 from typing import Any, Dict, Tuple, Union, AsyncGenerator
 from poe_api_wrapper import AsyncPoeApi
-from poe_api_wrapper.openai import helpers
-from poe_api_wrapper.openai.type import *
+import helpers
+from type import *
 import orjson, asyncio, random, os, uuid
 from httpx import AsyncClient
 


### PR DESCRIPTION
The FastAPI server was failing to start due to `ModuleNotFoundError: No module named 'poe_api_wrapper.openai'` in `api.py`. This commit corrects the import path/installation issue to resolve the error.