### PR TITLE
Add support of o1-preview, o1-mini, and fix claude-3.5-sonnet for the proxy server

### DIFF
--- a/poe_api_wrapper/openai/models.json
+++ b/poe_api_wrapper/openai/models.json
@@ -89,6 +89,24 @@
         "owned_by": "openai"
     },
 
+    "o1-mini": {
+        "baseModel": "o1_mini",
+        "tokens": 128000,
+        "endpoints": ["/v1/chat/completions"],
+        "premium_model": true,
+        "object": "model",
+        "owned_by": "openai"
+    },
+
+    "o1-preview": {
+        "baseModel": "o1_preview",
+        "tokens": 128000,
+        "endpoints": ["/v1/chat/completions"],
+        "premium_model": true,
+        "object": "model",
+        "owned_by": "openai"
+    },
+    
     "claude-instant": {
         "baseModel": "a2",
         "tokens": 9000,
@@ -180,7 +198,7 @@
     },
 
     "claude-3.5-sonnet": {
-        "baseModel": "claude_3_igloo",
+        "baseModel": "Claude-3.5-Sonnet",
         "tokens": 4000,
         "endpoints": ["/v1/chat/completions"],
         "premium_model": false,
@@ -189,7 +207,7 @@
     },
     
     "claude-3.5-sonnet-200k": {
-        "baseModel": "claude_3_igloo_200k",
+        "baseModel": "Claude-3.5-Sonnet-200k",
         "tokens": 200000,
         "endpoints": ["/v1/chat/completions"],
         "premium_model": false,


### PR DESCRIPTION
It seems POE changed how a bot is identified, which broke the usage of Claude 3.5 Sonnet in the proxy server. This PR fixes the issue by using the updated bot name and also added support for o1-preview and o1-mini.

How the code was tested:

1. `pip install -e .`
2. Server side:

```
from poe_api_wrapper import PoeServer
tokens = [
    {"p-b": p_b, "p-lat": p_lat},
]
PoeServer(tokens=tokens)
PoeServer(tokens=tokens, address="0.0.0.0", port="8080")
```

3. Client side:

```
import openai 
client = openai.OpenAI(api_key="anything", base_url="http://127.0.0.1:8080/v1/", default_headers={"Authorization": "Bearer anything"})

# Non-Streaming Example
response = client.chat.completions.create(
    model="o1-mini", 
    messages = [
                {"role": "user", "content": "Hi!"}
            ]
)

print(response.choices[0].message.content)
```

The test was performed on all four models.