### PR TITLE
Feat: Add extended message metadata to get_previous_messages()

### DIFF
--- a/README.md
+++ b/README.md
@@ -899,6 +899,14 @@ for message in previous_messages:
 {'author': 'human', 'text': 'nice to meet you', 'messageId': 2861709279}
 {'author': 'code_llama_34b_instruct', 'text': " Nice to meet you too! How are you doing today? Is there anything on your mind that you'd like to talk about? I'm here to listen and help", 'messageId': 2861873125}
 
+# Get messages with extended metadata (state and creationTime)
+# Using chatCode
+previous_messages = client.get_previous_messages('code_llama_34b_instruct', chatCode='2itg2a7muygs42v1u0k', include_extended=True)
+# Using chatId
+previous_messages = client.get_previous_messages('code_llama_34b_instruct', chatId=74411139, include_extended=True)
+>> Output:
+{'author': 'human', 'text': 'hi there', 'messageId': 2861363514, 'state': 'complete', 'creationTime': 1732029401216595}
+
 # Get all previous messages
 # Using chatCode
 previous_messages = client.get_previous_messages('code_llama_34b_instruct', chatCode='2itg2a7muygs42v1u0k', get_all=True)

--- a/poe_api_wrapper/api.py
+++ b/poe_api_wrapper/api.py
@@ -999,7 +999,7 @@ class PoeApi:
                 self.send_request('gql_POST', 'DeleteChat', {'chatId': chat})
                 logger.info(f"Chat {chat} deleted")  
                 
-    def get_previous_messages(self, bot: str, chatId: int = None, chatCode: str = None, count: int = 50, get_all: bool = False):
+    def get_previous_messages(self, bot: str, chatId: int = None, chatCode: str = None, count: int = 50, get_all: bool = False, include_extended: bool = False):
         bot = bot_map(bot)
         try:
             getchatdata = self.get_threadData(bot, chatCode, chatId)
@@ -1018,7 +1018,16 @@ class PoeApi:
                 chatdata = response_json['data']['node']
                 edges = chatdata['messagesConnection']['edges'][::-1]
                 for edge in edges:
-                    messages.append({'author': edge['node']['author'], 'text': edge['node']['text'], 'messageId': edge['node']['messageId'], 'contentType': edge['node']['contentType']})
+                    message = {
+                        'author': edge['node']['author'],
+                        'text': edge['node']['text'],
+                        'messageId': edge['node']['messageId'],
+                        'contentType': edge['node']['contentType']
+                    }
+                    if include_extended:
+                        message['state'] = edge['node'].get('state')
+                        message['creationTime'] = edge['node'].get('creationTime')
+                    messages.append(message)
                 cursor = chatdata['messagesConnection']['pageInfo']['startCursor']
         else:
             num = count
@@ -1028,7 +1037,16 @@ class PoeApi:
                 chatdata = response_json['data']['node']
                 edges = chatdata['messagesConnection']['edges'][::-1]
                 for edge in edges:
-                    messages.append({'author': edge['node']['author'], 'text': edge['node']['text'], 'messageId': edge['node']['messageId'], 'contentType': edge['node']['contentType']})
+                    message = {
+                        'author': edge['node']['author'],
+                        'text': edge['node']['text'],
+                        'messageId': edge['node']['messageId'],
+                        'contentType': edge['node']['contentType']
+                    }
+                    if include_extended:
+                        message['state'] = edge['node'].get('state')
+                        message['creationTime'] = edge['node'].get('creationTime')
+                    messages.append(message)
                     num -= 1
                     if len(messages) == count:
                         break

--- a/poe_api_wrapper/async_api.py
+++ b/poe_api_wrapper/async_api.py
@@ -1051,7 +1051,7 @@ class AsyncPoeApi:
                 await self.send_request('gql_POST', 'DeleteChat', {'chatId': chat})
                 logger.info(f"Chat {chat} deleted")  
                 
-    async def get_previous_messages(self, bot: str, chatId: int = None, chatCode: str = None, count: int = 50, get_all: bool = False):
+    async def get_previous_messages(self, bot: str, chatId: int = None, chatCode: str = None, count: int = 50, get_all: bool = False, include_extended: bool = False):
         bot = bot_map(bot)
         try:
             getchatdata = await self.get_threadData(bot, chatCode, chatId)
@@ -1070,7 +1070,16 @@ class AsyncPoeApi:
                 chatdata = response_json['data']['node']
                 edges = chatdata['messagesConnection']['edges'][::-1]
                 for edge in edges:
-                    messages.append({'author': edge['node']['author'], 'text': edge['node']['text'], 'messageId': edge['node']['messageId'], 'contentType': edge['node']['contentType']})
+                    message = {
+                        'author': edge['node']['author'],
+                        'text': edge['node']['text'],
+                        'messageId': edge['node']['messageId'],
+                        'contentType': edge['node']['contentType']
+                    }
+                    if include_extended:
+                        message['state'] = edge['node'].get('state')
+                        message['creationTime'] = edge['node'].get('creationTime')
+                    messages.append(message)
                 cursor = chatdata['messagesConnection']['pageInfo']['startCursor']
         else:
             num = count
@@ -1080,7 +1089,16 @@ class AsyncPoeApi:
                 chatdata = response_json['data']['node']
                 edges = chatdata['messagesConnection']['edges'][::-1]
                 for edge in edges:
-                    messages.append({'author': edge['node']['author'], 'text': edge['node']['text'], 'messageId': edge['node']['messageId'], 'contentType': edge['node']['contentType']})
+                    message = {
+                        'author': edge['node']['author'],
+                        'text': edge['node']['text'],
+                        'messageId': edge['node']['messageId'],
+                        'contentType': edge['node']['contentType']
+                    }
+                    if include_extended:
+                        message['state'] = edge['node'].get('state')
+                        message['creationTime'] = edge['node'].get('creationTime')
+                    messages.append(message)
                     num -= 1
                     if len(messages) == count:
                         break

--- a/poe_api_wrapper/queries.py
+++ b/poe_api_wrapper/queries.py
@@ -21,7 +21,7 @@ QUERIES = {
   "ChatHistoryListPaginationQuery": "6ce01455b0201e625489da90c65f87a2809d212ea41ab6e39412b6913990e81f",
   "ChatHomeMainInputContainerOptimisticBotQuery": "1c9267ecff73cb27a8e7d94a3f5b5fe665a82abe0fdd61be2e54dd38c0e61639",
   "ChatHomeMainInputContainerOptimisticViewerQuery": "21f0eb43ab07d97d4a30bcf007db4797b95e852fb6537e8dbbc002da45ba4fac",
-  "ChatListPaginationQuery": "e109d61fff512d58d84989aae2418a19167e3b6a9626d795b8a4f2bc84daf97c",
+  "ChatListPaginationQuery": "c1a8fd96dd6e0a4679814182951b1e256e175587513c81b223addf931833a692",
   "ChatLoaderQuery": "d9467ac216e21b510eb8e72a2888289d173c9d5ce399b072fd88bee3da1b1459",
   "ChatPageBotBotsPagination": "ed9017f85fe2fedbf02b2d000cb4b551d2ec870715d0c7bce6d54a0f3f9b657b",
   "ChatPageQuery": "e7dcf93e713a35a6b5642496b78339c9ef5ff0ae5e7e0c150ef534a738cced8c",


### PR DESCRIPTION
## Enhancement Overview  
Adds extended message metadata support to `get_previous_messages()` while maintaining backward compatibility.  

### Key Changes:  
1. **New `include_extended` Parameter**  
   - Returns `state` (message processing status) and `creationTime` (timestamp)  
   - Fully backward-compatible (default: `False`)  

2. **Documentation Update**  
   - Added README examples for extended metadata usage  

### Example:  
```python  
messages = client.get_previous_messages(
    'code_llama_34b_instruct', 
    chatCode='2itg2a7muygs42v1u0k', 
    include_extended=True
)  
# >> Output:  
# {'author': 'human', 'text': '...', 'state': 'complete', 'creationTime': 1732029401216595}  
```

### Important Notes:
- **Builds on `#221`**: Requires merged #221 for stable pagination
- **No Breaking Changes**: Original functionality preserved